### PR TITLE
Added reply to schema as children of posts

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -407,6 +407,75 @@
 							},
 							"title": {
 								"type": "string"
+							},
+							"notes": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"root_tumblelog_id": {
+											"type": "string"
+										},
+										"root_post_id": {
+											"type": "string"
+										},
+										"reply_id": {
+											"type": "string"
+										},
+										"parent_reply_id": {
+											"type": "null"
+										},
+										"created_time": {
+											"type": "string"
+										},
+										"from_user_id": {
+											"type": "string"
+										},
+										"from_tumblelog_id": {
+											"type": "string"
+										},
+										"tumblelog_id": {
+											"type": "string"
+										},
+										"post_id": {
+											"type": "string"
+										},
+										"state": {
+											"type": "string"
+										},
+										"depth": {
+											"type": "string"
+										},
+										"meta": {
+											"type": "object",
+											"properties": {
+												"npf_data": {
+													"type": "object",
+													"properties": {
+														"content": {
+															"type": "array",
+															"items": {
+																"type": "object",
+																"properties": {
+																	"type": {
+																		"type": "string"
+																	},
+																	"text": {
+																		"type": "string"
+																	}
+																}
+															}
+														},
+														"layout": {
+															"type": "array",
+															"items": {}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Includes reply note types only so we can get started testing standard reply types.

For now it does not include likes, tips and reblog notes etc, as it's a little unclear if these should be mapping to Wordpress comments.