### PR TITLE
Update reply schema with additional fields

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -99,12 +99,12 @@
 							"last_modified": {
 								"type": "string"
 							},
-              "tags": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
+							"tags": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							},
 							"meta": {
 								"type": "object",
 								"properties": {
@@ -495,57 +495,57 @@
 						}
 					}
 				},
-        "pages" : {
-          "description": "This array contains all the pages in the Tumblelog.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "path": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "content": {
-                "type": "string"
-              },
-              "position": {
-                "type": "integer"
-              },
-              "updated_at": {
-                "type": "integer"
-              },
-              "custom_template": {
-                "type": "boolean"
-              },
-              "show_link": {
-                "type": "boolean"
-              },
-              "is_redirect": {
-                "type": "boolean"
-              },
-              "url": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "likes": {
-          "description": "This array contains likes for the tumblelog's posts.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "root_post_id": {
-                "type": "string"
-              },
-              "timestamp": {
-                "type": "string"
-              },
-              "tumblelog_id": {
-                "description": "The ID of the user who liked the post.",
-                "type": "integer"
+				"pages" : {
+					"description": "This array contains all the pages in the Tumblelog.",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"path": {
+								"type": "string"
+							},
+							"title": {
+								"type": "string"
+							},
+							"content": {
+								"type": "string"
+							},
+							"position": {
+								"type": "integer"
+							},
+							"updated_at": {
+								"type": "integer"
+							},
+							"custom_template": {
+								"type": "boolean"
+							},
+							"show_link": {
+								"type": "boolean"
+							},
+							"is_redirect": {
+								"type": "boolean"
+							},
+							"url": {
+								"type": "string"
+							}
+						}
+					}
+				},
+				"likes": {
+					"description": "This array contains likes for the tumblelog's posts.",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"root_post_id": {
+								"type": "string"
+							},
+							"timestamp": {
+								"type": "string"
+							},
+							"tumblelog_id": {
+								"description": "The ID of the user who liked the post.",
+								"type": "integer"
 								}
 							}
 						}

--- a/schema.json
+++ b/schema.json
@@ -440,6 +440,12 @@
 										"from_tumblelog_id": {
 											"type": "string"
 										},
+										"from_tumblelog_name": {
+											"type": "string"
+										},
+										"from_tumblelog_url": {
+											"type": "string"
+										},
 										"tumblelog_id": {
 											"type": "string"
 										},
@@ -450,6 +456,9 @@
 											"type": "string"
 										},
 										"depth": {
+											"type": "string"
+										},
+										"text": {
 											"type": "string"
 										},
 										"meta": {
@@ -537,11 +546,11 @@
               "tumblelog_id": {
                 "description": "The ID of the user who liked the post.",
                 "type": "integer"
-              }
-            }
-          }
-        }
+								}
+							}
+						}
+					}
+				}
 			}
 		}
-	}
 }


### PR DESCRIPTION
This PR adds `text`, `from_tumblelog_url`, and `from_tumblelog_name` to replies schema. See https://github.tumblr.net/Tumblr/tumblr/pull/62915

It also converts some mixed spacing to tabs like the rest of the file.