### PR TITLE
Add media info to schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -491,6 +491,80 @@
 										}
 									}
 								}
+							},
+							"media": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"url": {
+											"type": "string",
+											"format": "uri"
+										},
+										"file_type": {
+											"type": "string"
+										},
+										"type": {
+											"type": "string",
+											"enum": ["audio", "image", "video"]
+										},
+										"meta": {
+											"type": "object",
+											"properties": {
+												"title": {
+													"type": "string"
+												},
+												"artist": {
+													"type": "string"
+												},
+												"album": {
+													"type": "string"
+												},
+												"alt_text": {
+													"type": "string"
+												},
+												"caption": {
+													"type": "string"
+												},
+												"exif": {
+													"type": "object"
+												}
+											}
+										},
+										"poster": {
+											"type": "object",
+											"properties": {
+												"url": {
+													"type": "string",
+													"format": "uri"
+												},
+												"file_type": {
+													"type": "string"
+												},
+												"type": {
+													"type": "string",
+													"enum": ["image"]
+												}
+											}
+										},
+										"filmstrip": {
+											"type": "object",
+											"properties": {
+												"url": {
+													"type": "string",
+													"format": "uri"
+												},
+												"file_type": {
+													"type": "string"
+												},
+												"type": {
+													"type": "string",
+													"enum": ["image"]
+												}
+											}
+										}
+									}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
This PR adds media info to the schema.

Below are some example responses for the 3 media types:

![Screenshot 2025-01-30 at 1 38 19 PM](https://github.com/user-attachments/assets/bfa9b2ea-2653-43ef-bb00-3a7aedbaa22e)
![Screenshot 2025-01-30 at 1 37 19 PM](https://github.com/user-attachments/assets/aeca274f-92ba-4e36-8af4-2950e76bf039)
![Screenshot 2025-01-30 at 1 36 48 PM](https://github.com/user-attachments/assets/1e5845f8-f810-4189-9de6-e2540bc4d2e7)
